### PR TITLE
upd: update policy 295

### DIFF
--- a/policies/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin.yml
+++ b/policies/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin.yml
@@ -9,18 +9,9 @@ policies:
   - name: ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin
     comment: '010023022001'
     description: |
-      Cloudfront origin uses not latest SSL certificate
+      Cloudfront origin uses deprecated version of SSL certificate
     resource: aws.distribution
     filters:
-      - and:
-          - type: value
-            key: Origins.Items[].CustomOriginConfig.OriginProtocolPolicy
-            value_type: swap
-            value: https-only
-            op: in
-          - not:
-              - type: value
-                key: Origins.Items[].CustomOriginConfig.OriginSslProtocols.Items[]
-                value_type: swap
-                value: TLSv1.2
-                op: in
+      - type: value
+        key: Origins.Items[?CustomOriginConfig && CustomOriginConfig.OriginProtocolPolicy!='http-only' && contains(CustomOriginConfig.OriginSslProtocols.Items, 'SSLv3')]
+        value: not-null

--- a/terraform/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/green/distribution.tf
+++ b/terraform/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/green/distribution.tf
@@ -1,6 +1,11 @@
 resource "aws_instance" "this" {
   ami           = data.aws_ami.this.id
   instance_type = "t2.micro"
+
+  tags = {
+    CustodianRule    = "ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin"
+    ComplianceStatus = "Green"
+  }
 }
 
 data "aws_ami" "this" {
@@ -25,7 +30,7 @@ resource "aws_cloudfront_distribution" "this" {
       origin_protocol_policy = "https-only"
       http_port              = "80"
       https_port             = "443"
-      origin_ssl_protocols   = ["TLSv1.2"]
+      origin_ssl_protocols   = ["TLSv1.2", "TLSv1.1"]
     }
   }
 

--- a/terraform/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/green2/cloudfront.tf
+++ b/terraform/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/green2/cloudfront.tf
@@ -1,0 +1,48 @@
+resource "aws_s3_bucket" "this" {
+  bucket = "bucket-295-red"
+}
+
+locals {
+  s3_origin_id = "myRedS3"
+}
+
+resource "random_integer" "this" {
+  min = 1
+  max = 10000000
+}
+
+resource "aws_cloudfront_distribution" "this" {
+  origin {
+    domain_name = aws_s3_bucket.this.bucket_regional_domain_name
+    origin_id   = local.s3_origin_id
+  }
+
+  enabled             = true
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = local.s3_origin_id
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "allow-all"
+  }
+  
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}

--- a/terraform/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/green2/provider.tf
+++ b/terraform/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/green2/provider.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5"
+    }
+  }
+}
+
+provider "aws"{
+  profile = var.profile
+  region = var.default-region
+
+  default_tags {
+    tags = {
+      CustodianRule    = "ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin"
+      ComplianceStatus = "Green2"
+    }
+  }
+}

--- a/terraform/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/green2/terraform.tfvars
+++ b/terraform/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/green2/terraform.tfvars
@@ -1,0 +1,2 @@
+profile        = "c7n"
+default-region = "us-east-1"

--- a/terraform/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/green2/variables.tf
+++ b/terraform/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/green2/variables.tf
@@ -1,0 +1,9 @@
+variable "default-region" {
+  type        = string
+  description = "Default region for resources will be created"
+}
+
+variable "profile" {
+  type        = string
+  description = "Profile name configured before running apply"
+}

--- a/terraform/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/red2/distribution.tf
+++ b/terraform/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/red2/distribution.tf
@@ -1,11 +1,6 @@
 resource "aws_instance" "this" {
   ami           = data.aws_ami.this.id
   instance_type = "t2.micro"
-
-  tags = {
-    CustodianRule    = "ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin"
-    ComplianceStatus = "Red"
-  }
 }
 
 data "aws_ami" "this" {
@@ -27,10 +22,10 @@ resource "aws_cloudfront_distribution" "this" {
     domain_name = aws_instance.this.public_dns
     origin_id   = local.ec2_origin_id
     custom_origin_config {
-      origin_protocol_policy = "https-only"
       http_port              = "80"
       https_port             = "443"
-      origin_ssl_protocols   = ["SSLv3"]
+      origin_protocol_policy = "match-viewer"
+      origin_ssl_protocols   = ["TLSv1.2", "SSLv3"]
     }
   }
 

--- a/terraform/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/red2/index.html
+++ b/terraform/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/red2/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <title>Basic Web Page</title>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+
+<style>
+  body {
+    height: 100vh;
+    width: 100vw;
+    background-color: aquamarine;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    font-size: 42px;
+    font-family: mono;
+  }
+</style>
+
+<body>
+  Hello World!
+
+  <script>
+    console.log('Hello world!');
+  </script>
+</body>
+
+</html>

--- a/terraform/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/red2/provider.tf
+++ b/terraform/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/red2/provider.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5"
+    }
+  }
+}
+
+provider "aws"{
+  profile = var.profile
+  region = var.default-region
+
+  default_tags {
+    tags = {
+      CustodianRule    = "ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin"
+      ComplianceStatus = "Red"
+    }
+  }
+}

--- a/terraform/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/red2/terraform.tfvars
+++ b/terraform/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/red2/terraform.tfvars
@@ -1,0 +1,2 @@
+profile        = "c7n"
+default-region = "us-east-1"

--- a/terraform/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/red2/variables.tf
+++ b/terraform/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/red2/variables.tf
@@ -1,0 +1,9 @@
+variable "default-region" {
+  type        = string
+  description = "Default region for resources will be created"
+}
+
+variable "profile" {
+  type        = string
+  description = "Profile name configured before running apply"
+}

--- a/tests/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/placebo-red/cloudfront.ListDistributions_1.json
+++ b/tests/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/placebo-red/cloudfront.ListDistributions_1.json
@@ -6,23 +6,23 @@
             "Marker": "",
             "MaxItems": 100,
             "IsTruncated": false,
-            "Quantity": 4,
+            "Quantity": 1,
             "Items": [
                 {
-                    "Id": "E32QEHSIE8V7TF",
-                    "ARN": "arn:aws:cloudfront::111111111111:distribution/E32QEHSIE8V7TF",
+                    "Id": "E3153VPXBPXF29",
+                    "ARN": "arn:aws:cloudfront::644160558196:distribution/E3153VPXBPXF29",
                     "Status": "Deployed",
                     "LastModifiedTime": {
                         "__class__": "datetime",
-                        "year": 2022,
-                        "month": 5,
-                        "day": 20,
-                        "hour": 13,
-                        "minute": 32,
-                        "second": 12,
-                        "microsecond": 356000
+                        "year": 2024,
+                        "month": 11,
+                        "day": 7,
+                        "hour": 20,
+                        "minute": 33,
+                        "second": 52,
+                        "microsecond": 982000
                     },
-                    "DomainName": "d2ohku0rzi86fg.cloudfront.net",
+                    "DomainName": "d13h6bfmht7o6q.cloudfront.net",
                     "Aliases": {
                         "Quantity": 0
                     },
@@ -31,7 +31,7 @@
                         "Items": [
                             {
                                 "Id": "myEC2Origin",
-                                "DomainName": "ec2-3-84-182-11.compute-1.amazonaws.com",
+                                "DomainName": "ec2-54-160-178-196.compute-1.amazonaws.com",
                                 "OriginPath": "",
                                 "CustomHeaders": {
                                     "Quantity": 0
@@ -43,7 +43,7 @@
                                     "OriginSslProtocols": {
                                         "Quantity": 1,
                                         "Items": [
-                                            "TLSv1.1"
+                                            "SSLv3"
                                         ]
                                     },
                                     "OriginReadTimeout": 30,
@@ -53,7 +53,8 @@
                                 "ConnectionTimeout": 10,
                                 "OriginShield": {
                                     "Enabled": false
-                                }
+                                },
+                                "OriginAccessControlId": ""
                             }
                         ]
                     },
@@ -135,16 +136,17 @@
                             "RestrictionType": "whitelist",
                             "Quantity": 4,
                             "Items": [
-                                "US",
                                 "CA",
+                                "DE",
                                 "GB",
-                                "DE"
+                                "US"
                             ]
                         }
                     },
                     "WebACLId": "",
                     "HttpVersion": "HTTP2",
-                    "IsIPV6Enabled": false
+                    "IsIPV6Enabled": false,
+                    "Staging": false
                 }
             ]
         }

--- a/tests/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/placebo-red/tagging.GetResources_1.json
+++ b/tests/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/placebo-red/tagging.GetResources_1.json
@@ -4,15 +4,15 @@
         "PaginationToken": "",
         "ResourceTagMappingList": [
             {
-                "ResourceARN": "arn:aws:cloudfront::111111111111:distribution/E32QEHSIE8V7TF",
+                "ResourceARN": "arn:aws:cloudfront::644160558196:distribution/E3153VPXBPXF29",
                 "Tags": [
-                    {
-                        "Key": "ComplianceStatus",
-                        "Value": "Red"
-                    },
                     {
                         "Key": "CustodianRule",
                         "Value": "ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin"
+                    },
+                    {
+                        "Key": "ComplianceStatus",
+                        "Value": "Red"
                     }
                 ]
             }

--- a/tests/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/red_policy_test.py
+++ b/tests/ecc-aws-295-use_secure_ssl_protocols_between_cloudfront_origin/red_policy_test.py
@@ -2,4 +2,4 @@ class PolicyTest(object):
 
      def test_resources(self, base_test, resources):
         base_test.assertEqual(len(resources), 1)
-        base_test.assertEqual(resources[0]['Origins']['Items'][0]['CustomOriginConfig']['OriginSslProtocols']['Items'][0], 'TLSv1.1')
+        base_test.assertEqual(resources[0]['Origins']['Items'][0]['CustomOriginConfig']['OriginSslProtocols']['Items'][0], 'SSLv3')


### PR DESCRIPTION
The policy filter logic has been changed to check deprecated SSLv3 protocol instead of checking for the latest version of TLS.